### PR TITLE
Alarm clock

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -147,7 +147,9 @@ int thread_get_load_avg (void);
 void do_iret (struct intr_frame *tf);
 
 /* Alarm Clock */
-void thread_sleep(int64_t ticks);
-void thread_awake(int64_t ticks);
+void thread_sleep (int64_t ticks);
+void thread_awake (int64_t ticks);
+void update_next_tick_to_awake (int64_t ticks);
+int64_t get_next_tick_to_awake (void);
 
 #endif /* threads/thread.h */


### PR DESCRIPTION
이전 코드의 Alarm Clock은 sleep_list에서 깨워야할 쓰레드를 찾습니다. 시간 소모를 줄이기 위해 코드를 변경하였습니다.
next_tick_to_awake는 전역 변수로 sleep_list의 쓰레드들의 wakeup_tick의 최소값을 저장하는 변수입니다.
sleep_list의 쓰레드들 중에서 가장 먼저 깨워야할 쓰레드의 wakeup_tick으로 현재 쓰레드(curr)의 tick이 더  작을 경우 update_next_tick_to_awake () 함수로 갱신합니다.
get_next_tick_to_awake () 함수를 통해 next_tick_to_awake를 반환합니다.