### PR TITLE
Priority Inversion

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -25,4 +25,4 @@ make
 cd build
 source ../../activate
 
-$PRIORITY_SEMA
+$PRIORITY_DONATE_CHAIN

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -167,5 +167,6 @@ bool cmp_priority (const struct list_elem *a, const struct list_elem *b, void *a
 void donate_priority (void);
 void remove_with_lock (struct lock * lock);
 void refresh_priority (void);
+bool cmp_donate_priority (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 
 #endif /* threads/thread.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -163,4 +163,9 @@ int64_t get_next_tick_to_awake (void);
 void test_max_priority (void);
 bool cmp_priority (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 
+/* Priority Inversion */
+void donate_priority (void);
+void remove_with_lock (struct lock * lock);
+void refresh_priority (void);
+
 #endif /* threads/thread.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -101,9 +101,9 @@ struct thread {
 	/* Priority Inversion */
 	int init_priority;
 
-	struct lock *wait_lock;
-	struct list donation_list;
-	struct list_elem doantion_elem;
+	struct lock *wait_on_lock;
+	struct list donations;
+	struct list_elem donation_elem;
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -98,6 +98,13 @@ struct thread {
 	/* Alarm Clock */
 	int64_t wakeup_ticks; // 스레드가 일어날 시간
 
+	/* Priority Inversion */
+	int init_priority;
+
+	struct lock *wait_lock;
+	struct lock *donation;
+	struct list_elem doantion_elem;
+
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -102,7 +102,7 @@ struct thread {
 	int init_priority;
 
 	struct lock *wait_lock;
-	struct lock *donation;
+	struct list donation_list;
 	struct list_elem doantion_elem;
 
 #ifdef USERPROG

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -196,6 +196,9 @@ lock_acquire (struct lock *lock) {
 
 	sema_down (&lock->semaphore);
 	lock->holder = thread_current ();
+
+	// lock을 점유하고 있는 쓰레드와 요청하고 있는 쓰레드의 우선순위 비교
+	// priority donation 수행
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -230,6 +233,9 @@ lock_release (struct lock *lock) {
 
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);
+
+	// release되면 cpu를 점유한 후 donation list에서 쓰레드 제거
+	// 우선순위 다시 계산
 }
 
 /* Returns true if the current thread holds LOCK, false

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -198,7 +198,7 @@ lock_acquire (struct lock *lock) {
 	lock->holder = thread_current ();
 
 	// lock을 점유하고 있는 쓰레드와 요청하고 있는 쓰레드의 우선순위 비교
-	// priority donation 수행
+	donate_priority ();
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -235,7 +235,10 @@ lock_release (struct lock *lock) {
 	sema_up (&lock->semaphore);
 
 	// release되면 cpu를 점유한 후 donation list에서 쓰레드 제거
+	remove_with_lock (&lock);
+	
 	// 우선순위 다시 계산
+	refresh_priority ();
 }
 
 /* Returns true if the current thread holds LOCK, false

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -204,8 +204,9 @@ lock_acquire (struct lock *lock) {
 	}
 
 	sema_down (&lock->semaphore);
+	/* Priority Inversion */
 	curr->wait_on_lock = NULL;
-	lock->holder = thread_current ();
+	lock->holder = curr;
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -227,7 +228,6 @@ lock_try_acquire (struct lock *lock) {
 	return success;
 }
 
-// error
 /* Releases LOCK, which must be owned by the current thread.
    This is lock_release function.
 
@@ -239,6 +239,7 @@ lock_release (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
+	/* Priority Inversion */
 	remove_with_lock (lock);
 	refresh_priority ();
 

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -432,7 +432,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->magic = THREAD_MAGIC;
 
 	/* Priority Inversion */
-	t->init_priority = priority; // 생성시 기본 우선순위와 동일
+	t->init_priority = priority;
 	t->wait_on_lock = NULL;
 	list_init (&t->donations);
 }
@@ -746,4 +746,13 @@ void refresh_priority (void) {
 		curr->priority = max_priority;
 	}
 
+}
+
+/* Priority Inversion */
+bool
+cmp_donate_priority (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	struct thread* thread_a = list_entry(a, struct thread, donation_elem);
+	struct thread* thread_b = list_entry(b, struct thread, donation_elem);
+
+	return thread_a->priority > thread_b->priority;
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -430,6 +430,11 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
+
+	/* Priority Inversion */
+	t->init_priority = priority;
+	t->wait_lock = NULL;
+	list_init (&t->donation);
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -330,7 +330,10 @@ thread_yield (void) {
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
+	/* Priority Inversion */
+	thread_current ()->init_priority = new_priority;
+	refresh_priority ();
+
 	/* Priority Scheduling */
 	test_max_priority ();
 }
@@ -694,19 +697,16 @@ cmp_priority (const struct list_elem *a, const struct list_elem *b, void *aux UN
 }
 
 /* Priority Inversion */
+/* Perform priority donation. */
 void
 donate_priority (void) {
 	// priority donation을 수행
 	struct thread *curr = thread_current ();
-	int priority = curr->priority;
 	int depth = 0;
-	while ((curr->wait_on_lock != NULL) && (depth < 8)) {
-		struct thread *nested = curr->wait_on_lock->holder;
-		if (nested->priority > curr->priority) {
-			nested->priority = curr->priority;
-			curr = nested;
-		}
-		nested++;
+	while ((curr->wait_on_lock != NULL) && (depth < 9)) {
+		depth++;
+		curr->wait_on_lock->holder->priority = curr->priority;
+		curr = curr->wait_on_lock->holder;
 	}
 }
 
@@ -714,27 +714,30 @@ donate_priority (void) {
 /* Remove the thread entry from the donation_list. */
 void
 remove_with_lock (struct lock *lock) {
-	struct thread *curr = thread_current ();
-	struct list *donation_list = &curr->donations;
+	struct list *donation_list = &thread_current ()->donations;
 	struct list_elem *curr_elem = list_begin (donation_list);
 
-	while (curr_elem != list_tail(donation_list)) {
+	while (curr_elem != list_end(donation_list)) {
 		struct thread *t = list_entry (curr_elem, struct thread, donation_elem);
 
 		if (t->wait_on_lock == lock) {
-			curr_elem = list_remove (&t->donation_elem);
+			curr_elem = list_remove (curr_elem);
 		}
-		curr_elem = list_next (curr_elem);
+		else {
+			curr_elem = list_next (curr_elem);
+		}
 	}
 }
 
 /* Priority Inversion */
+/* Recalculate the priority. */
 void 
 refresh_priority (void) {
 	struct thread *curr = thread_current ();
 	struct list *donation_list = &curr->donations;                
-	curr->priority = curr->init_priority;
 	int max_priority = curr->priority;
+
+	curr->priority = curr->init_priority;
 
 	if (!list_empty (donation_list)) {
 		struct list_elem *curr_elem = list_front (donation_list);
@@ -749,6 +752,7 @@ refresh_priority (void) {
 }
 
 /* Priority Inversion */
+/* Compare the donated priority of the thread. */
 bool
 cmp_donate_priority (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
 	struct thread* thread_a = list_entry(a, struct thread, donation_elem);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -692,3 +692,19 @@ cmp_priority (const struct list_elem *a, const struct list_elem *b, void *aux UN
 
 	return thread_a->priority > thread_b->priority;
 }
+
+/* Priority Inversion */
+void
+donate_priority (void) {
+	// priority donation을 수행
+}
+
+/* Priority Inversion */
+void remove_with_lock (struct lock *lock) {
+	// donation_list에서 쓰레드 엔트리 제거
+}
+
+/* Priority Inversion */
+void refresh_priority (void) {
+	// 우선순위를 다시 계산
+}

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -711,26 +711,26 @@ donate_priority (void) {
 }
 
 /* Priority Inversion */
-void remove_with_lock (struct lock *lock) {
-	// donation_list에서 쓰레드 엔트리 제거
+/* Remove the thread entry from the donation_list. */
+void
+remove_with_lock (struct lock *lock) {
 	struct thread *curr = thread_current ();
 	struct list *donation_list = &curr->donations;
-	struct list_elem *curr_elem = list_front (donation_list);
+	struct list_elem *curr_elem = list_begin (donation_list);
 
-	while (list_empty(donation_list) && (curr_elem != list_tail(donation_list)) ) {
+	while (curr_elem != list_tail(donation_list)) {
 		struct thread *t = list_entry (curr_elem, struct thread, donation_elem);
 
 		if (t->wait_on_lock == lock) {
 			curr_elem = list_remove (&t->donation_elem);
 		}
-		else {
-			curr_elem = list_next (curr_elem);
-		}
+		curr_elem = list_next (curr_elem);
 	}
 }
 
 /* Priority Inversion */
-void refresh_priority (void) {
+void 
+refresh_priority (void) {
 	struct thread *curr = thread_current ();
 	struct list *donation_list = &curr->donations;                
 	curr->priority = curr->init_priority;

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -432,9 +432,9 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->magic = THREAD_MAGIC;
 
 	/* Priority Inversion */
-	t->init_priority = priority;
+	t->init_priority = priority; // 생성시 기본 우선순위와 동일
 	t->wait_lock = NULL;
-	list_init (&t->donation);
+	list_init (&t->donation_list);
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
@@ -697,11 +697,27 @@ cmp_priority (const struct list_elem *a, const struct list_elem *b, void *aux UN
 void
 donate_priority (void) {
 	// priority donation을 수행
+	struct thread *curr = thread_current ();
+	while (!donation_list) {
+		struct thread *holder = curr->wait_lock->holder;
+		if (holder->priority > curr->priority) {
+			holder->priority = curr->priority;
+			curr = holder;
+		}
+
+	}
 }
 
 /* Priority Inversion */
 void remove_with_lock (struct lock *lock) {
 	// donation_list에서 쓰레드 엔트리 제거
+	struct thread *curr = thread_current ();
+	struct list_elem *e = &curr->donation_elem;
+	struct list *donation = &curr->donation_list;
+
+	while (!donation) {
+		struct thread *t = list_entry (e, struct thread, donation_elem);
+	}
 }
 
 /* Priority Inversion */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -698,13 +698,15 @@ void
 donate_priority (void) {
 	// priority donation을 수행
 	struct thread *curr = thread_current ();
-	while (!donation_list) {
-		struct thread *holder = curr->wait_lock->holder;
-		if (holder->priority > curr->priority) {
-			holder->priority = curr->priority;
-			curr = holder;
+	int priority = curr->priority;
+	int depth = 0;
+	while ((curr->wait_lock != NULL) && (depth < 8)) {
+		struct thread *nested = curr->wait_lock->holder;
+		if (nested->priority > curr->priority) {
+			nested->priority = curr->priority;
+			curr = nested;
 		}
-
+		nested++;
 	}
 }
 
@@ -712,10 +714,10 @@ donate_priority (void) {
 void remove_with_lock (struct lock *lock) {
 	// donation_list에서 쓰레드 엔트리 제거
 	struct thread *curr = thread_current ();
-	struct list_elem *e = &curr->donation_elem;
 	struct list *donation = &curr->donation_list;
+	struct list_elem *curr_e = list_front (donation);
 
-	while (!donation) {
+	while (list_empty(donation) && (curr_e != lsit_tail(donation)) ) {
 		struct thread *t = list_entry (e, struct thread, donation_elem);
 	}
 }


### PR DESCRIPTION
Priority Scheduling에서 다중 쓰레드 환경인 경우에 우선순위가 높은 쓰레드가 낮은 쓰레드를 기다리는 역전 문제가 발생합니다. 쓰레드의 우선순위를 기부하는 Priority Donation 방법으로 해결합니다.
