### PR TITLE
Multi-Level Feedback Queue Scheduler

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -128,6 +128,18 @@ timer_interrupt (struct intr_frame *args UNUSED) {
 	ticks++;
 	thread_tick ();
 
+	/* Multi Level Feedback Queue Scheduler */
+	if (thread_mlfqs) {
+		mlfqs_increment ();
+		if (ticks % 4 == 0) {
+			mlfqs_priority (thread_current ());
+			if (ticks % TIMER_FREQ == 0) {
+				mlfqs_load_avg ();
+				mlfqs_recalc ();
+			}
+		}
+	}
+
 	/* Alarm Clcok */
 	thread_awake (ticks);
 }

--- a/do.sh
+++ b/do.sh
@@ -17,15 +17,15 @@ PRIORITY_PREEMPT="pintos -v -- -q run priority-preempt"
 PRIORITY_SEMA="pintos -v -- -q run priority-sema"
 PRIORITY_CONDVAR="pintos -v -- -q run priority-condvar"
 PRIORITY_DONATE_CHAIN="pintos -v -- -q run priority-donate-chain"
-MLFQS_LOAD_1="pintos -v -- -q run mlfqs-load-1"
-MLFQS_LOAD_60="pintos -v -- -q run mlfqs-load-60"
-MLFQS_LOAD_AVG="pintos -v -- -q run mlfqs-load-avg"
-MLFQS_RECENT_1="pintos -v -- -q run mlfqs-recent-1"
-MLFQS_FAIR_2="pintos -v -- -q run mlfqs-fair-2"
-MLFQS_FAIR_20="pintos -v -- -q run mlfqs-fair-20"
-MLFQS_NICE_2="pintos -v -- -q run mlfqs-nice-2"
-MLFQS_NICE_10="pintos -v -- -q run mlfqs-nice-10"
-MLFQS_BLOCK="pintos -v -- -q run mlfqs-block"
+MLFQS_LOAD_1="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-load-1"
+MLFQS_LOAD_60="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-load-60"
+MLFQS_LOAD_AVG="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-load-avg "
+MLFQS_RECENT_1="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-recent-1"
+MLFQS_FAIR_2="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-fair-2"
+MLFQS_FAIR_20="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-fair-20"
+MLFQS_NICE_2="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-nice-2"
+MLFQS_NICE_10="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-nice-10"
+MLFQS_BLOCK="pintos -v -k -T 480 -m 20   -- -q  -mlfqs run mlfqs-block"
 
 cd threads
 make clean
@@ -33,4 +33,4 @@ make
 cd build
 source ../../activate
 
-$PRIORITY_SEMA
+$MLFQS_LOAD_AVG

--- a/do.sh
+++ b/do.sh
@@ -33,4 +33,4 @@ make
 cd build
 source ../../activate
 
-$MLFQS_LOAD_AVG
+$MLFQS_RECENT_1

--- a/do.sh
+++ b/do.sh
@@ -17,7 +17,15 @@ PRIORITY_PREEMPT="pintos -v -- -q run priority-preempt"
 PRIORITY_SEMA="pintos -v -- -q run priority-sema"
 PRIORITY_CONDVAR="pintos -v -- -q run priority-condvar"
 PRIORITY_DONATE_CHAIN="pintos -v -- -q run priority-donate-chain"
-COW_SIMPLE="pintos -v -- -q run cow-simple"
+MLFQS_LOAD_1="pintos -v -- -q run mlfqs-load-1"
+MLFQS_LOAD_60="pintos -v -- -q run mlfqs-load-60"
+MLFQS_LOAD_AVG="pintos -v -- -q run mlfqs-load-avg"
+MLFQS_RECENT_1="pintos -v -- -q run mlfqs-recent-1"
+MLFQS_FAIR_2="pintos -v -- -q run mlfqs-fair-2"
+MLFQS_FAIR_20="pintos -v -- -q run mlfqs-fair-20"
+MLFQS_NICE_2="pintos -v -- -q run mlfqs-nice-2"
+MLFQS_NICE_10="pintos -v -- -q run mlfqs-nice-10"
+MLFQS_BLOCK="pintos -v -- -q run mlfqs-block"
 
 cd threads
 make clean
@@ -25,4 +33,4 @@ make
 cd build
 source ../../activate
 
-$PRIORITY_DONATE_CHAIN
+$PRIORITY_SEMA

--- a/include/threads/fixed_point.h
+++ b/include/threads/fixed_point.h
@@ -1,0 +1,60 @@
+#define F (1 << 14)
+#define INT_MAX ((1 << 31) - 1)
+#define INT_MIN (-(1 << 31))
+
+int int_to_fp (int n);
+int fp_to_int_round (int x);
+int fp_to_int (int x);
+int add_fp (int x, int y);
+int add_mixed (int x, int n);
+int sub_fp (int x, int y);
+int sub_mixed (int x, int n);
+int mult_fp (int x, int y);
+int mult_mixed (int x, int y);
+int div_fp (int x, int y);
+int div_mixed (int x, int n);
+
+int int_to_fp (int n) {
+  return n * F;
+}
+
+int fp_to_int (int x) {
+  return x / F;
+}
+
+int fp_to_int_round (int x) {
+  if (x >= 0) return (x + F / 2) / F;
+  else return (x - F / 2) / F;
+}
+
+int add_fp (int x, int y) {
+  return x + y;
+}
+
+int sub_fp (int x, int y) {
+  return x - y;
+}
+
+int add_mixed (int x, int n) {
+  return x + n * F;
+}
+
+int sub_mixed (int x, int n) {
+  return x - n * F;
+}
+
+int mult_fp (int x, int y) {
+  return ((int64_t) x) * y / F;
+}
+
+int mult_mixed (int x, int n) {
+  return x * n;
+}
+
+int div_fp (int x, int y) {
+  return ((int64_t) x) * F / y;
+}
+
+int div_mixed (int x, int n) {
+  return x / n;
+}

--- a/include/threads/fixed_point.h
+++ b/include/threads/fixed_point.h
@@ -1,3 +1,5 @@
+/* Multi Level Feedback Queue Scheduler */
+
 #define F (1 << 14)
 #define INT_MAX ((1 << 31) - 1)
 #define INT_MIN (-(1 << 31))
@@ -15,46 +17,46 @@ int div_fp (int x, int y);
 int div_mixed (int x, int n);
 
 int int_to_fp (int n) {
-  return n * F;
+    return n * F;
 }
 
 int fp_to_int (int x) {
-  return x / F;
+    return x / F;
 }
 
 int fp_to_int_round (int x) {
-  if (x >= 0) return (x + F / 2) / F;
-  else return (x - F / 2) / F;
+    if (x >= 0) return (x + F / 2) / F;
+    else return (x - F / 2) / F;
 }
 
 int add_fp (int x, int y) {
-  return x + y;
+    return x + y;
 }
 
 int sub_fp (int x, int y) {
-  return x - y;
+    return x - y;
 }
 
 int add_mixed (int x, int n) {
-  return x + n * F;
+    return x + n * F;
 }
 
 int sub_mixed (int x, int n) {
-  return x - n * F;
+    return x - n * F;
 }
 
 int mult_fp (int x, int y) {
-  return ((int64_t) x) * y / F;
+    return ((int64_t) x) * y / F;
 }
 
 int mult_mixed (int x, int n) {
-  return x * n;
+    return x * n;
 }
 
 int div_fp (int x, int y) {
-  return ((int64_t) x) * F / y;
+    return ((int64_t) x) * F / y;
 }
 
 int div_mixed (int x, int n) {
-  return x / n;
+    return x / n;
 }

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -28,6 +28,11 @@ typedef int tid_t;
 #define PRI_DEFAULT 31                  /* Default priority. */
 #define PRI_MAX 63                      /* Highest priority. */
 
+/* Multi Level Feedback Queue Scheduler */
+#define NICE_DEFAULT 0
+#define RECENT_CPU_DEFAULT 0
+#define LOAD_AVG_DEFAULT 0
+
 /* A kernel thread or user process.
  *
  * Each thread structure is stored in its own 4 kB page.  The
@@ -105,6 +110,10 @@ struct thread {
 	struct list donations;
 	struct list_elem donation_elem;
 
+	/* Multi Level Feedback Queue Scheduler */
+	int nice;
+	int recent_cpu;
+
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */
@@ -168,5 +177,12 @@ void donate_priority (void);
 void remove_with_lock (struct lock * lock);
 void refresh_priority (void);
 bool cmp_donate_priority (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+
+/* Multi Level Feedback Queue Scheduler */
+void mlfqs_priority (struct thread *t);
+void mlfqs_recent_cpu (struct thread *t);
+void mlfqs_load_avg (void);
+void mlfqs_increment (void);
+void mlfqs_recalc (void);
 
 #endif /* threads/thread.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -184,5 +184,6 @@ void mlfqs_recent_cpu (struct thread *t);
 void mlfqs_load_avg (void);
 void mlfqs_increment (void);
 void mlfqs_recalc (void);
+void mlfqs_update_thread (struct thread *t);
 
 #endif /* threads/thread.h */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -143,6 +143,7 @@ thread_start (void) {
 	sema_init (&idle_started, 0);
 	thread_create ("idle", PRI_MIN, idle, &idle_started);
 
+	/* Multi Level Feedback Queue Scheduler */
 	load_avg = LOAD_AVG_DEFAULT;
 
 	/* Start preemptive thread scheduling. */
@@ -857,21 +858,10 @@ mlfqs_recalc (void) {
 	mlfqs_recent_cpu (curr);
 	mlfqs_priority (curr);
 
-	while (ready_elem != list_tail (&ready_list)) {
+	while (ready_elem != list_end (&ready_list)) {
 		struct thread *ready_thread = list_entry (ready_elem, struct thread, elem);
 		mlfqs_recent_cpu (ready_thread);
 		mlfqs_priority (ready_thread);
-		printf("ready pre list_next\n");
 		ready_elem = list_next (ready_elem);
-		printf("ready next list_next\n");
-	}
-
-	while (sleep_elem != list_tail (&sleep_elem)) {
-		struct thread *sleep_thread = list_entry (sleep_elem, struct thread, elem);
-		mlfqs_recent_cpu (sleep_thread);
-		mlfqs_priority (sleep_thread);
-		printf("sleep pre list_next\n");
-		sleep_elem =list_next (sleep_elem);
-		printf("sleep next list_next\n");
 	}
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -56,6 +56,7 @@ static long long user_ticks;    /* # of timer ticks in user programs. */
 /* Alarm Clcok */
 static long long next_tick_to_awake;
 
+/* Multi Level Feedback Queue Scheduler */
 int load_avg;
 
 /* Scheduling. */
@@ -804,7 +805,7 @@ cmp_donate_priority (const struct list_elem *a, const struct list_elem *b, void 
 }
 
 /* Multi Level Feedback Queue Scheduler */
-/* 인자로 주어진 쓰레드의 priority를 업데이트 */
+/* Update the priority of the thread provided as an argument. */
 void 
 mlfqs_priority (struct thread *t) {
 	if (t == idle_thread) {
@@ -815,7 +816,7 @@ mlfqs_priority (struct thread *t) {
 }
 
 /* Multi Level Feedback Queue Scheduler */
-/* 인자로 주어진 쓰레드의 recent_cpu를 업데이트 */
+/* Update the recent_cpu of the thread provided as an argument. */
 void
 mlfqs_recent_cpu (struct thread *t) {
 	if (t == idle_thread) {
@@ -825,7 +826,7 @@ mlfqs_recent_cpu (struct thread *t) {
 }
 
 /* Multi Level Feedback Queue Scheduler */
-/* 시스템의 load_avg를 업데이트 */
+/* Update the system's load_avg. */
 void 
 mlfqs_load_avg (void) {
 	int size = list_size (&ready_list);
@@ -837,7 +838,7 @@ mlfqs_load_avg (void) {
 }
 
 /* Multi Level Feedback Queue Scheduler */
-/* 현재 수행중인 쓰레드의 recent_cpu를 1증가 시킴 */
+/* Increment the recent_cpu of the currently executing thread by 1. */
 void 
 mlfqs_increment (void) {
 	struct thread *curr = thread_current ();
@@ -848,7 +849,7 @@ mlfqs_increment (void) {
 }
 
 /* Multi Level Feedback Queue Scheduler */
-/* 모든 쓰레드의 priority, recent_cpu를 업데이트 */
+/* Update the priority and recent_cpu of all threads. */
 void
 mlfqs_recalc (void) {
 	struct thread *curr = thread_current ();
@@ -871,6 +872,7 @@ mlfqs_recalc (void) {
 }
 
 /* Multi Level Feedback Queue Scheduler */
+/* Execute mlfqs_recent_cpu and mlfqs_priority for the thread provided as an argument. */
 void
 mlfqs_update_thread (struct thread *t) {
 	mlfqs_recent_cpu (t);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -338,12 +338,15 @@ thread_yield (void) {
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
-	/* Priority Inversion */
-	thread_current ()->init_priority = new_priority;
-	refresh_priority ();
+	/* Multi Level Feedback Queue Scheduler */
+	if (!thread_mlfqs) {
+		/* Priority Inversion */
+		thread_current ()->init_priority = new_priority;
+		refresh_priority ();
 
-	/* Priority Scheduling */
-	test_max_priority ();
+		/* Priority Scheduling */
+		test_max_priority ();
+	}
 }
 
 /* Returns the current thread's priority. */
@@ -355,7 +358,14 @@ thread_get_priority (void) {
 /* Sets the current thread's nice value to NICE. */
 void
 thread_set_nice (int nice UNUSED) {
-	/* TODO: Your implementation goes here */
+	/* Multi Level Feedback Queue Scheduler */
+	enum intr_level old_level = intr_disable ();
+
+	thread_current ()->nice = nice;
+	mlfqs_priority (thread_current ());
+	test_max_priority ();
+
+	intr_set_level (old_level);
 }
 
 /* Returns the current thread's nice value. */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -822,7 +822,7 @@ mlfqs_recent_cpu (struct thread *t) {
 	if (t == idle_thread) {
 		return ;
 	}
-	t->recent_cpu = mult_fp(div_fp(mult_mixed(load_avg, 2), (mult_mixed(load_avg, 2) + int_to_fp(1))), t->recent_cpu) + int_to_fp(t->nice);
+	t->recent_cpu = mult_fp (div_fp (mult_mixed (load_avg, 2), (mult_mixed (load_avg, 2) + int_to_fp (1))), t->recent_cpu) + int_to_fp (t->nice);
 }
 
 /* Multi Level Feedback Queue Scheduler */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -11,6 +11,10 @@
 #include "threads/synch.h"
 #include "threads/vaddr.h"
 #include "intrinsic.h"
+
+/* Multi Level Feedback Queue Scheduler */
+#include "threads/fixed_point.h"
+
 #ifdef USERPROG
 #include "userprog/process.h"
 #endif
@@ -438,6 +442,10 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->init_priority = priority;
 	t->wait_on_lock = NULL;
 	list_init (&t->donations);
+
+	/* Multi Level Feedback Queue Scheduler */
+	t->nice = NICE_DEFAULT;
+	t->recent_cpu = LOAD_AVG_DEFAULT;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
@@ -759,4 +767,39 @@ cmp_donate_priority (const struct list_elem *a, const struct list_elem *b, void 
 	struct thread* thread_b = list_entry(b, struct thread, donation_elem);
 
 	return thread_a->priority > thread_b->priority;
+}
+
+/* Multi Level Feedback Queue Scheduler */
+/* 인자로 주어진 쓰레드의 priority를 업데이트 */
+void 
+mlfqs_priority (struct thread *t) {
+
+}
+
+/* Multi Level Feedback Queue Scheduler */
+/* 인자로 주어진 쓰레드의 recent_cpu를 업데이트 */
+void
+mlfqs_recent_cpu (struct thread *t) {
+
+}
+
+/* Multi Level Feedback Queue Scheduler */
+/* 시스템의 load_avg를 업데이트 */
+void 
+mlfqs_load_avg (void) {
+
+}
+
+/* Multi Level Feedback Queue Scheduler */
+/* 현재 수행중인 쓰레드의 recent_cpu를 1증가 시킴 */
+void 
+mlfqs_increment (void) {
+
+}
+
+/* Multi Level Feedback Queue Scheduler */
+/* 모든 쓰레드의 priority, recent_cpu를 업데이트 */
+void
+mlfqs_recalc (void) {
+
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -371,22 +371,41 @@ thread_set_nice (int nice UNUSED) {
 /* Returns the current thread's nice value. */
 int
 thread_get_nice (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+	/* Multi Level Feedback Queue Scheduler */
+	enum intr_level old_level = intr_disable ();
+
+	int nice_value = thread_current ()->nice;
+
+	intr_set_level (old_level);
+
+	return nice_value;
 }
 
 /* Returns 100 times the system load average. */
 int
 thread_get_load_avg (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+	/* Multi Level Feedback Queue Scheduler */
+	enum intr_level old_level = intr_disable ();
+
+	int load_avg_value = fp_to_int_round (mult_mixed (load_avg, 100));
+
+	intr_set_level (old_level);
+
+	return load_avg_value;
 }
 
 /* Returns 100 times the current thread's recent_cpu value. */
 int
 thread_get_recent_cpu (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+	/* Multi Level Feedback Queue Scheduler */
+	enum intr_level old_level = intr_disable ();
+
+	struct thread *curr = thread_current ();
+	int recent_cpu_value = fp_to_int_round (mult_mixed (curr->recent_cpu, 100));
+
+	intr_set_level (old_level);
+
+	return recent_cpu_value;
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.
@@ -826,6 +845,7 @@ mlfqs_increment (void) {
 	}
 }
 
+/* error */
 /* Multi Level Feedback Queue Scheduler */
 /* 모든 쓰레드의 priority, recent_cpu를 업데이트 */
 void
@@ -841,13 +861,17 @@ mlfqs_recalc (void) {
 		struct thread *ready_thread = list_entry (ready_elem, struct thread, elem);
 		mlfqs_recent_cpu (ready_thread);
 		mlfqs_priority (ready_thread);
+		printf("ready pre list_next\n");
 		ready_elem = list_next (ready_elem);
+		printf("ready next list_next\n");
 	}
 
 	while (sleep_elem != list_tail (&sleep_elem)) {
 		struct thread *sleep_thread = list_entry (sleep_elem, struct thread, elem);
 		mlfqs_recent_cpu (sleep_thread);
 		mlfqs_priority (sleep_thread);
+		printf("sleep pre list_next\n");
 		sleep_elem =list_next (sleep_elem);
+		printf("sleep next list_next\n");
 	}
 }


### PR DESCRIPTION
우선순위 스케줄링은 높은 우선순위의 쓰레드만 CPU를 점유할 경우에 낮은 쓰레드는 대기하는 기아현상이 발생합니다. 
이는  자원을 기다리는 쓰레드들이 많아져서 평균 대기 시간이 길어집니다.

MLFQS는 우선 순위가 낮은 큐에서 더 많은 시간을 소비한 작업은 우선순위를 높이는 방향으로 이동하여 동작합니다.
nice는 CPU를 요청 시 쓰레드의 우선순위를 결정하는 데 사용합니다.
낮은 nice 값이 가진 쓰레드가 CPU를 할당 받을 수 있습니다.

기아 상태를 완전히 제거하지 않지만, 낮은 우선 순위에도 할당 기회를 부여해서 기아 상태를 줄입니다.