### PR TITLE
User memory access

### DIFF
--- a/include/userprog/syscall.h
+++ b/include/userprog/syscall.h
@@ -3,4 +3,7 @@
 
 void syscall_init (void);
 
+/* User Memory Access */
+void check_address (void *addr);
+
 #endif /* userprog/syscall.h */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -44,3 +44,16 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	printf ("system call!\n");
 	thread_exit ();
 }
+
+/* User Memory Access */
+// 주소 값이 유저 영역에서 사용하는 주소 값인지 확인
+// 유저 영역을 벗어난 영역일 경우 프로세스 종료
+void
+check_address (void *addr) {
+	if (addr == NULL) {
+		exit (-1);
+	}
+	if (!is_user_vaddr (addr)) {
+		exit (-1);
+	}
+}

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -51,7 +51,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 void
 check_address (void *addr) {
 	struct thread *curr = thread_current ();
-	if (addr == NULL || !(is_user_vaddr (addr)) || pml4_get_page(curr->pml4, addr) == NULL) {
+	if (addr == NULL || is_kernel_vaddr(addr) || pml4_get_page(curr->pml4, addr) == NULL) {
 		exit(-1);
 	}
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -46,14 +46,12 @@ syscall_handler (struct intr_frame *f UNUSED) {
 }
 
 /* User Memory Access */
-// 주소 값이 유저 영역에서 사용하는 주소 값인지 확인
-// 유저 영역을 벗어난 영역일 경우 프로세스 종료
+/* Check if the address value is within the range of addresses used by the user space. */
+/* If the address is outside the user space, terminate the process. */
 void
 check_address (void *addr) {
-	if (addr == NULL) {
-		exit (-1);
-	}
-	if (!is_user_vaddr (addr)) {
-		exit (-1);
+	struct thread *curr = thread_current ();
+	if (addr == NULL || !(is_user_vaddr (addr)) || pml4_get_page(curr->pml4, addr) == NULL) {
+		exit(-1);
 	}
 }


### PR DESCRIPTION
주소 값이 유저 영역에서 사용하는 주소 값인지 확인합니다.
유저 영역을 벗어난 경우 프로세스를 종료합니다.

1. 주소 값이 NULL인 경우
2. 커널 가상 주소의 영역인 경우
3. 쓰레드의 페이지 매핑 정보(pml4)에 매핑되어 있지 않는 경우